### PR TITLE
Add Image3D to Frameworks & Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -867,6 +867,8 @@ This README is intended to work as a fast research index:
 
 - [ThreeDee AI 3D Bust Maker - Generate 3D busts from single photo](https://www.threedee.design/products/3d-bust-maker/), ThreeDee, Product 2026
 
+- [Image3D - Generate downloadable 3D models from a single image](https://image3d.io/), Image3D, Product 2026
+
 
 ## Tutorial Videos :tv:
 


### PR DESCRIPTION
Adds Image3D to the Frameworks & Projects section as a browser-based product for generating downloadable 3D models from a single image.

I kept this as a single concise entry, matching the nearby ThreeDee product entries.