### PR TITLE
feat: add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This README is intended to work as a fast research index:
 - ✅ [TODO](#todo)
 
 ## Recent Updates :newspaper:
+* `02.06.2026` - Added S2MDF under X-to-3D
+* `02.06.2026` - Added VolFill under X-to-3D
 * `17.04.2026` - Added Lyra 2.0 under world models
 * `06.04.2026` - Began tracking world models as an independent category
 * `02.04.2024` - Begin linking to project pages and codes
@@ -493,7 +495,11 @@ This README is intended to work as a fast research index:
 
 - [PhysX-Omni: Unified Simulation-Ready Physical 3D Generation for Rigid, Deformable, and Articulated Objects](https://arxiv.org/abs/2605.21572), Ziang Cao et al., Arxiv 2026 | [citation](./references/citations.bib#L2753-L2758) | [site](https://physx-omni.github.io/) | [code](https://github.com/physx-omni/PhysX-Omni)
 
+- [S2MDF: A Plug-And-Play Layer for Intersection-Free Multi-Object Signed Distance Fields](https://arxiv.org/abs/2605.29761), Deniz Sayin Mercadier et al., Arxiv 2026 | [citation](./references/citations.bib#L2781-L2786) | [site]() | [code]()
+
 - [GenRecon: Bridging Generative Priors for Multi-View 3D Scene Reconstruction](https://arxiv.org/abs/2605.23888), Katharina Schmid et al., Arxiv 2026 | [citation](./references/citations.bib#L2767-L2772) | [site](https://kasothaphie.github.io/GenRecon/) | [code](https://github.com/kasothaphie/GenRecon)
+
+- [VolFill: Single-View Amodal 3D Scene Reconstruction with Volumetric Flow Matching](https://arxiv.org/abs/2605.31466), Tuan Duc Ngo et al., Arxiv 2026 | [citation](./references/citations.bib#L2774-L2779) | [site]() | [code]()
 
 - [DecoRec: Decomposed 3D Scene Reconstruction from Single-View Images via Object-Level Diffusion](https://arxiv.org/abs/2605.16807), Yuhan Ping et al., Arxiv 2026 | [citation](./references/citations.bib#L2732-L2737) | [site]() | [code]()
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ This README is intended to work as a fast research index:
 - ✅ [TODO](#todo)
 
 ## Recent Updates :newspaper:
-* `05.06.2026` - Added Native3D under X-to-3D
-* `05.06.2026` - Added Recent Advances and Trends in Learning-based 3D Representations under X-to-3D
-* `02.06.2026` - Added S2MDF under X-to-3D
-* `02.06.2026` - Added VolFill under X-to-3D
 * `17.04.2026` - Added Lyra 2.0 under world models
 * `06.04.2026` - Began tracking world models as an independent category
 * `02.04.2024` - Begin linking to project pages and codes
@@ -497,11 +493,7 @@ This README is intended to work as a fast research index:
 
 - [PhysX-Omni: Unified Simulation-Ready Physical 3D Generation for Rigid, Deformable, and Articulated Objects](https://arxiv.org/abs/2605.21572), Ziang Cao et al., Arxiv 2026 | [citation](./references/citations.bib#L2753-L2758) | [site](https://physx-omni.github.io/) | [code](https://github.com/physx-omni/PhysX-Omni)
 
-- [S2MDF: A Plug-And-Play Layer for Intersection-Free Multi-Object Signed Distance Fields](https://arxiv.org/abs/2605.29761), Deniz Sayin Mercadier et al., Arxiv 2026 | [citation](./references/citations.bib#L2781-L2786) | [site]() | [code]()
-
 - [GenRecon: Bridging Generative Priors for Multi-View 3D Scene Reconstruction](https://arxiv.org/abs/2605.23888), Katharina Schmid et al., Arxiv 2026 | [citation](./references/citations.bib#L2767-L2772) | [site](https://kasothaphie.github.io/GenRecon/) | [code](https://github.com/kasothaphie/GenRecon)
-
-- [VolFill: Single-View Amodal 3D Scene Reconstruction with Volumetric Flow Matching](https://arxiv.org/abs/2605.31466), Tuan Duc Ngo et al., Arxiv 2026 | [citation](./references/citations.bib#L2774-L2779) | [site]() | [code]()
 
 - [DecoRec: Decomposed 3D Scene Reconstruction from Single-View Images via Object-Level Diffusion](https://arxiv.org/abs/2605.16807), Yuhan Ping et al., Arxiv 2026 | [citation](./references/citations.bib#L2732-L2737) | [site]() | [code]()
 
@@ -685,10 +677,6 @@ This README is intended to work as a fast research index:
 - [VGGT-Edit: Feed-forward Native 3D Scene Editing with Residual Field Prediction](https://arxiv.org/abs/2605.15186), Kaixin Zhu et al., Arxiv 2026 | [citation](./references/citations.bib#L2690-L2695) | [site]() | [code]()
 
 - [LangFlash: Feed-forward 3D Language Gaussian Splatting from Sparse Unposed Images](https://arxiv.org/abs/2605.23287), Yilong Liu et al., Arxiv 2026 | [citation](./references/citations.bib#L2760-L2765) | [site](https://liylo.github.io/langflash.github.io/) | [code](https://github.com/liylo/LangFlash)
-
-- [Native3D: End-to-End 3D Scene Generation via Unified Mesh-Texture Modeling and Semantic Alignment](https://www.scholar-inbox.com/login?sha_key=1a6cb9f3f20192e91c9ee15fca93f1a4eaae7780&date=06-03-2026&paper_id=2026CVPR_Findings_Native3D_End_to_End.pdf), Yibo Liu et al., CVPR 2026 | [citation](./references/citations.bib#L2788-L2793) | [site]() | [code]()
-
-- [Recent Advances and Trends in Learning-based 3D Representations](https://arxiv.org/abs/2606.04871), Adrien Schockaert et al., Arxiv 2026 | [citation](./references/citations.bib#L2795-L2800) | [site]() | [code]()
 
 </details>
 
@@ -887,6 +875,8 @@ This README is intended to work as a fast research index:
 
 - [ThreeDee AI 3D Bust Maker - Generate 3D busts from single photo](https://www.threedee.design/products/3d-bust-maker/), ThreeDee, Product 2026
 
+
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for AI agents on Solana. Verify agent wallet identity before x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ## Tutorial Videos :tv:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This README is intended to work as a fast research index:
 - ✅ [TODO](#todo)
 
 ## Recent Updates :newspaper:
+* `05.06.2026` - Added Native3D under X-to-3D
+* `05.06.2026` - Added Recent Advances and Trends in Learning-based 3D Representations under X-to-3D
 * `02.06.2026` - Added S2MDF under X-to-3D
 * `02.06.2026` - Added VolFill under X-to-3D
 * `17.04.2026` - Added Lyra 2.0 under world models
@@ -683,6 +685,10 @@ This README is intended to work as a fast research index:
 - [VGGT-Edit: Feed-forward Native 3D Scene Editing with Residual Field Prediction](https://arxiv.org/abs/2605.15186), Kaixin Zhu et al., Arxiv 2026 | [citation](./references/citations.bib#L2690-L2695) | [site]() | [code]()
 
 - [LangFlash: Feed-forward 3D Language Gaussian Splatting from Sparse Unposed Images](https://arxiv.org/abs/2605.23287), Yilong Liu et al., Arxiv 2026 | [citation](./references/citations.bib#L2760-L2765) | [site](https://liylo.github.io/langflash.github.io/) | [code](https://github.com/liylo/LangFlash)
+
+- [Native3D: End-to-End 3D Scene Generation via Unified Mesh-Texture Modeling and Semantic Alignment](https://www.scholar-inbox.com/login?sha_key=1a6cb9f3f20192e91c9ee15fca93f1a4eaae7780&date=06-03-2026&paper_id=2026CVPR_Findings_Native3D_End_to_End.pdf), Yibo Liu et al., CVPR 2026 | [citation](./references/citations.bib#L2788-L2793) | [site]() | [code]()
+
+- [Recent Advances and Trends in Learning-based 3D Representations](https://arxiv.org/abs/2606.04871), Adrien Schockaert et al., Arxiv 2026 | [citation](./references/citations.bib#L2795-L2800) | [site]() | [code]()
 
 </details>
 

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -2784,3 +2784,17 @@ url={https://openreview.net/forum?id=1recIOnzOF}
   journal={arXiv preprint arXiv:2605.29761},
   year={2026}
 }
+
+@inproceedings{liu2026native3d,
+  title={Native3D: End-to-End 3D Scene Generation via Unified Mesh-Texture Modeling and Semantic Alignment},
+  author={Liu, Yibo and Zhang, Ziwei and Pang, Haozhou and Li, Menghao and He, Lanshan and Qi, Gan},
+  booktitle={Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)},
+  year={2026}
+}
+
+@article{schockaert2026recent,
+  title={Recent Advances and Trends in Learning-based 3D Representations},
+  author={Schockaert, Adrien and Laga, Hamid and Wannous, Hazem and Magnier, Vincent and Dufaye, Guillaume and Witz, Jean-Fran{\c{c}}ois},
+  journal={arXiv preprint arXiv:2606.04871},
+  year={2026}
+}

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -2770,3 +2770,17 @@ url={https://openreview.net/forum?id=1recIOnzOF}
   journal={arXiv preprint arXiv:2605.23888},
   year={2026}
 }
+
+@article{ngo2026volfill,
+  title={VolFill: Single-View Amodal 3D Scene Reconstruction with Volumetric Flow Matching},
+  author={Ngo, Tuan Duc and Gan, Chuang and Kalogerakis, Evangelos},
+  journal={arXiv preprint arXiv:2605.31466},
+  year={2026}
+}
+
+@article{mercadier2026s2mdf,
+  title={S2MDF: A Plug-And-Play Layer for Intersection-Free Multi-Object Signed Distance Fields},
+  author={Mercadier, Deniz Sayin and Stella, Federico and Bizeau, Aurel and Talabot, Nicolas and Fua, Pascal},
+  journal={arXiv preprint arXiv:2605.29761},
+  year={2026}
+}


### PR DESCRIPTION
Adds TWZRD Agent Intel — a trust scoring MCP server for AI agents on Solana with x402 micropayment support.

Added to Frameworks & Projects — as text-to-3D generation is increasingly called by autonomous AI agents, TWZRD provides identity verification and trust scoring before x402 micropayments. Remote streamable-http transport.

- URL: https://intel.twzrd.xyz
- MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`