### PR TITLE
Add July 2026 3D generation papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ This README is intended to work as a fast research index:
 
 - [UnfoldArt: Zero-Shot Recovery of Full Articulated 3D Objects from Text or Image](https://arxiv.org/abs/2606.30608), Mohamed El Amine Boudjoghra et al., Arxiv 2026 | [citation](./references/citations.bib#L2914-L2919) | [site](https://aminebdj.github.io/unfoldart/) | [code](https://github.com/aminebdj/UnfoldArt)
 
+- [PixGS: Pixel-Space Diffusion for Direct 3D Gaussian Splat Generation](https://arxiv.org/abs/2607.01803), Duy Cao et al., ECCV 2026 | [citation](./references/citations.bib#L2935-L2940) | [site]() | [code]()
+
 
 </details>
 
@@ -821,6 +823,8 @@ This README is intended to work as a fast research index:
 - [4D-fy:Text-to-4D Generation Using Hybrid Score Distillation Sampling](https://arxiv.org/abs/2311.17984), Lincong Feng et al., Arxiv 2023 | [citation](./references/citations.bib#L842-L847) | [site](https://sherwinbahmani.github.io/4dfy/) | [code](https://github.com/sherwinbahmani/4dfy)
 
 - [GeoDiff4D: Geometry-Aware Diffusion for 4D Head Avatar Reconstruction](https://arxiv.org/abs/2602.24161), Chao Xu et al., Arxiv 2026 | [citation](./references/citations.bib#L2523-L2528) | [site](https://lyxcc127.github.io/geodiff4d/) | [code](https://github.com/lyxcc127/GeoDiff4D)
+
+- [Alignment Is All You Need For X-to-4D Generation](https://arxiv.org/abs/2607.02516), Qiaowei Miao et al., Arxiv 2026 | [citation](./references/citations.bib#L2942-L2947) | [site](https://miaoqiaowei.github.io/Align4D/) | [code]()
 
 
 

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -2931,3 +2931,17 @@ url={https://openreview.net/forum?id=1recIOnzOF}
   journal={arXiv preprint arXiv:2607.01202},
   year={2026}
 }
+
+@article{cao2026pixgs,
+  title={PixGS: Pixel-Space Diffusion for Direct 3D Gaussian Splat Generation},
+  author={Cao, Duy and Nguyen-Ha, Phong},
+  journal={arXiv preprint arXiv:2607.01803},
+  year={2026}
+}
+
+@article{miao2026alignment,
+  title={Alignment Is All You Need For X-to-4D Generation},
+  author={Miao, Qiaowei and Li, Kehan and Luo, Yawei and Yang, Yi},
+  journal={arXiv preprint arXiv:2607.02516},
+  year={2026}
+}


### PR DESCRIPTION
Adds two July 2026 papers to the Awesome Text-to-3D index:

- PixGS under X-to-3D
- Alignment Is All You Need For X-to-4D Generation under Dynamic Content Generation

Also adds matching BibTeX entries for both papers.

Validation:
- Compared `add-july-2026-papers` against `dev`; only `README.md` and `references/citations.bib` changed.