### PR TITLE
Add WanToFight and Hallo4D papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,8 @@ This README is intended to work as a fast research index:
 
 - [OmniX: Any-view and Any-time 4D Reconstruction via Feed-forward Trajectory Fields](https://arxiv.org/abs/2607.10840), Yanqin Jiang et al., ECCV 2026 | [citation](./references/citations.bib#L2991-L2996) | [site](https://omnix4d.github.io/) | [code](https://github.com/yanqinJiang/OmniX)
 
+- [Hallo4D: Multi-Modal Hallucination Mitigation for Consistent Spatio-Temporal Generation](https://arxiv.org/abs/2607.12752), Hongbo Wang et al., Arxiv 2026 | [citation](./references/citations.bib#L3005-L3010) | [site](https://wafer-bob.github.io/Hallo3D-4D/) | [code]()
+
 
 
 </details>
@@ -873,6 +875,8 @@ This README is intended to work as a fast research index:
 - [World from Motion: Generative Dynamic Gaussian Reconstruction from Monocular Video](https://arxiv.org/abs/2607.01202), Liyuan Zhu et al., Arxiv 2026 | [citation](./references/citations.bib#L2928-L2933) | [site](https://research.nvidia.com/labs/amri/projects/world-from-motion/) | [code]()
 
 - [ABot-3DWorld 0: A Universal World Model to Explore Any 3D Space](https://arxiv.org/abs/2607.11673), Mingchao Sun et al., Arxiv 2026 | [citation](./references/citations.bib#L2984-L2989) | [site](https://abot-world.amap.com/) | [code]()
+
+- [WanToFight: Real-Time Generative Game Engine for Multi-Player Combat Interaction](https://arxiv.org/abs/2607.12592), Li Hu et al., Arxiv 2026 | [citation](./references/citations.bib#L2998-L3003) | [site](https://humanaigc.github.io/wantofight/) | [code]()
 
 </details>
 

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -2994,3 +2994,17 @@ url={https://openreview.net/forum?id=1recIOnzOF}
   booktitle={European Conference on Computer Vision (ECCV)},
   year={2026}
 }
+
+@article{hu2026wantofight,
+  title={WanToFight: Real-Time Generative Game Engine for Multi-Player Combat Interaction},
+  author={Hu, Li and Wang, Guangyuan and Zhang, Peng and Zhang, Bang},
+  journal={arXiv preprint arXiv:2607.12592},
+  year={2026}
+}
+
+@article{wang2026hallo4d,
+  title={Hallo4D: Multi-Modal Hallucination Mitigation for Consistent Spatio-Temporal Generation},
+  author={Wang, Hongbo and Huang, Huaibo and Cao, Jie and Liu, Jin and Tong, Haoyang and He, Ran},
+  journal={arXiv preprint arXiv:2607.12752},
+  year={2026}
+}


### PR DESCRIPTION
## Summary
- add WanToFight under World Models
- add Hallo4D under Dynamic Content Generation
- add matching BibTeX entries and exact citation anchors

## Validation
- `git diff --check`
- staged scope limited to `README.md` and `references/citations.bib`