### PR TITLE
Add five reconstruction and avatar papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,8 @@ This README is intended to work as a fast research index:
 
 - [Event3R: Asynchronous-to-Global 3D Reconstruction from Event Camera via Spatial-Temporal Feature Aggregation](https://arxiv.org/abs/2607.15727), Jian Huang et al., IROS 2026 | [citation](./references/citations.bib#L3117-L3122) | [site]() | [code]()
 
+- [Convolutional Neural Shading for High-Quality 3D Reconstruction from Multi-View Images](https://arxiv.org/abs/2607.28132), Juheon Hwang et al., Multimedia Systems 2025 | [citation](./references/citations.bib#L3152-L3157) | [site]() | [code]()
+
 
 </details>
 
@@ -842,6 +844,12 @@ This README is intended to work as a fast research index:
 
 - [FlexiAvatar: Unified 3D Gaussian Human Avatars Under Arbitrary Body Visibility](https://arxiv.org/abs/2607.19100), Yihalem Yimolal Tiruneh et al., ECCV 2026 | [citation](./references/citations.bib#L3138-L3143) | [site]() | [code]()
 
+- [S-Avatar: Diffusion-Guided Gaussian Head Avatars from a Single Image](https://arxiv.org/abs/2607.28164), Hail Song et al., Arxiv 2026 | [citation](./references/citations.bib#L3159-L3164) | [site](https://github.com/hailsong/savatar) | [code](https://github.com/hailsong/savatar)
+
+- [Bunraku: Turning a Single Illustration into an Editable Live2D Character](https://arxiv.org/abs/2607.27348), Junhao Chen et al., Arxiv 2026 | [citation](./references/citations.bib#L3166-L3171) | [site](https://bunraku-live2d.github.io/) | [code]()
+
+- [EgoGVAE: Ego-body Mesh Reconstruction via Guided Variational Autoencoder](https://arxiv.org/abs/2607.27755), Jaehun Jung et al., ECCV 2026 | [citation](./references/citations.bib#L3180-L3185) | [site]() | [code]()
+
 </details>
 
 <a id="dynamic-content-generation"></a>
@@ -867,6 +875,8 @@ This README is intended to work as a fast research index:
 - [Online Neural Space Time Memory for Dynamic Novel View Synthesis](https://arxiv.org/abs/2607.15271), Baback Elmieh et al., Arxiv 2026 | [citation](./references/citations.bib#L3110-L3115) | [site](https://nst-mem.github.io) | [code]()
 
 - [AniGS: Bridging Rendering and Diffusion Prior for 3D Scene Animation](https://arxiv.org/abs/2607.18539), Yen-Chi Cheng et al., Arxiv 2026 | [citation](./references/citations.bib#L3124-L3129) | [site](https://yccyenchicheng.github.io/AniGS/) | [code]()
+
+- [4DHumanDiff: Direct Text-to-4DGS Generation for Consistent 360-Degree Dynamic Humans](https://arxiv.org/abs/2607.27634), Renlong Wu et al., Arxiv 2026 | [citation](./references/citations.bib#L3173-L3178) | [site]() | [code]()
 
 
 

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -3148,3 +3148,38 @@ url={https://openreview.net/forum?id=1recIOnzOF}
   journal={arXiv preprint arXiv:2607.26646},
   year={2026}
 }
+
+@article{hwang2025convolutional,
+  title={Convolutional Neural Shading for High-Quality 3D Reconstruction from Multi-View Images},
+  author={Hwang, Juheon and Kim, Taewan and Oh, Heeseok and Kang, Jiwoo},
+  journal={Multimedia Systems},
+  year={2025}
+}
+
+@article{song2026savatar,
+  title={S-Avatar: Diffusion-Guided Gaussian Head Avatars from a Single Image},
+  author={Song, Hail and Yang, Seokhwan and Yang, Jiwon and Cho, Woojin and Woo, Woontack},
+  journal={arXiv preprint arXiv:2607.28164},
+  year={2026}
+}
+
+@article{chen2026bunraku,
+  title={Bunraku: Turning a Single Illustration into an Editable Live2D Character},
+  author={Chen, Junhao and Mao, Jingjia and Li, Dayong and Li, Chenghai and Zhang, Saining and Li, Zhihao and Zhao, Hao and Wang, Yufei and Huang, Ruqi},
+  journal={arXiv preprint arXiv:2607.27348},
+  year={2026}
+}
+
+@article{wu2026fourdhumandiff,
+  title={4DHumanDiff: Direct Text-to-4DGS Generation for Consistent 360-Degree Dynamic Humans},
+  author={Wu, Renlong and Chen, Haoran and Wei, Yuxiang and Jin, Xiaowei and Zuo, Wangmeng and Li, Hui},
+  journal={arXiv preprint arXiv:2607.27634},
+  year={2026}
+}
+
+@inproceedings{jung2026egogvae,
+  title={EgoGVAE: Ego-body Mesh Reconstruction via Guided Variational Autoencoder},
+  author={Jung, Jaehun and Kim, Wonjun},
+  booktitle={European Conference on Computer Vision (ECCV)},
+  year={2026}
+}


### PR DESCRIPTION
## Summary

- add Convolutional Neural Shading under X-to-3D
- add S-Avatar, Bunraku, and EgoGVAE under Avatar Generation and Manupilation
- add 4DHumanDiff under Dynamic Content Generation
- add matching BibTeX records and verified citation anchors

## Validation

- `git diff --check`
- citation anchors verified against final BibTeX line numbers
- only `README.md` and `references/citations.bib` are included