### PR TITLE
Add Luce, SceneReGen, NeoWorld-Pro, and ExMesh++

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,14 @@ This README is intended to work as a fast research index:
 
 - [FixAnything: 3D-Consistent Rendering Refinement via Video Generative Priors](https://arxiv.org/abs/2608.23549), Khiem Vuong et al., ECCV 2026 | [citation](./references/citations.bib#L3341-L3346) | [site](https://fix-anything.github.io/) | [code](https://github.com/kvuong2711/fix-anything)
 
+- [Luce: Relightable Gaussians for 3D Asset Generation](https://arxiv.org/abs/2608.23943), Mayank Singh et al., Arxiv 2026 | [citation](./references/citations.bib#L3355-L3360) | [site]() | [code]()
+
+- [SceneReGen: Generative Reconstruction of 3D Scenes from a Single Image](https://arxiv.org/abs/2608.23930), Zefan Tian et al., Arxiv 2026 | [citation](./references/citations.bib#L3362-L3367) | [site]() | [code]()
+
+- [NeoWorld-Pro: Programming Interactive Scenes from Monocular Images for Embodied Simulation](https://arxiv.org/abs/2608.24212), Yumeng He et al., Arxiv 2026 | [citation](./references/citations.bib#L3369-L3374) | [site](https://raynehe.github.io/PRISM/) | [code]()
+
+- [ExMesh++: From Multi-View Images to Relightable UV-PBR Mesh Assets via Topology-Adaptive Reconstruction and Decomposition](https://arxiv.org/abs/2608.24109), Chuanjin Fan et al., Arxiv 2026 | [citation](./references/citations.bib#L3376-L3381) | [site]() | [code]()
+
 </details>
 
 <a id="3d-editing-decomposition--stylization"></a>

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -3351,3 +3351,31 @@ url={https://openreview.net/forum?id=1recIOnzOF}
   booktitle={European Conference on Computer Vision (ECCV)},
   year={2026}
 }
+
+@article{singh2026luce,
+  title={Luce: Relightable Gaussians for 3D Asset Generation},
+  author={Singh, Mayank and Stoppa, Michele and Memo, Alvise and Yu, Rui and Kalli, Harsha and Gunturi, Srimanth and Riaz, Muhammad Ahmed and Shahsavari, Behrooz and Abdulla, Waleed and Jacobs, David E.},
+  journal={arXiv preprint arXiv:2608.23943},
+  year={2026}
+}
+
+@article{tian2026sceneregen,
+  title={SceneReGen: Generative Reconstruction of 3D Scenes from a Single Image},
+  author={Tian, Zefan and Ye, Yuteng and Zhang, Yiheng and Yang, Yuhang and Lv, Xueqiang and Zhang, Shizhou and Liu, Le and Xu, Di},
+  journal={arXiv preprint arXiv:2608.23930},
+  year={2026}
+}
+
+@article{he2026neoworldpro,
+  title={NeoWorld-Pro: Programming Interactive Scenes from Monocular Images for Embodied Simulation},
+  author={He, Yumeng and Song, Yichen and Yang, Xiaotian and Zhang, Weijia and Zhou, Zanwei and Gong, Junru and Yang, Xiaokang and Wang, Yunbo},
+  journal={arXiv preprint arXiv:2608.24212},
+  year={2026}
+}
+
+@article{fan2026exmeshplusplus,
+  title={ExMesh++: From Multi-View Images to Relightable UV-PBR Mesh Assets via Topology-Adaptive Reconstruction and Decomposition},
+  author={Fan, Chuanjin and Wu, Lifan and Chang, Wenjie and Chang, Hanzhi and Yang, Wenfei and Zhang, Tianzhu},
+  journal={arXiv preprint arXiv:2608.24109},
+  year={2026}
+}


### PR DESCRIPTION
## Summary
- add Luce, SceneReGen, NeoWorld-Pro, and ExMesh++ to the X-to-3D index
- add matching BibTeX entries with final README citation anchors
- include the verified NeoWorld-Pro project page

## Validation
- `git diff --check`
- verified README citation anchors against `references/citations.bib`