### PR TITLE
Add three 3D world papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,8 @@ This README is intended to work as a fast research index:
 
 - [ExMesh++: From Multi-View Images to Relightable UV-PBR Mesh Assets via Topology-Adaptive Reconstruction and Decomposition](https://arxiv.org/abs/2608.24109), Chuanjin Fan et al., Arxiv 2026 | [citation](./references/citations.bib#L3376-L3381) | [site]() | [code]()
 
+- [Cross-Platform Benchmark of Neural 3D Reconstruction for Autonomous Laboratory Robots](https://arxiv.org/abs/2608.26383), Yongho Kim et al., Arxiv 2026 | [citation](./references/citations.bib#L3383-L3388) | [site]() | [code]()
+
 </details>
 
 <a id="3d-editing-decomposition--stylization"></a>
@@ -979,6 +981,10 @@ This README is intended to work as a fast research index:
 - [WorldClaw: Agentic 3D Open-World Generation at Scale](https://arxiv.org/abs/2608.05248), Chunchao Guo et al., Arxiv 2026 | [citation](./references/citations.bib#L3250-L3255) | [site](https://tencent-hunyuan.github.io/Hunyuan3D-WorldClaw/) | [code](https://github.com/Tencent-Hunyuan/Hunyuan3D-WorldClaw)
 
 - [StateFlow: Building, Evolving, and Accessing 3D World States for Previsualization](https://arxiv.org/abs/2608.12314), Yuyang Yin et al., Arxiv 2026 | [citation](./references/citations.bib#L3271-L3276) | [site](https://yuyangyin.github.io/StateFlow/) | [code]()
+
+- [4DSynth: Controllable Procedural World Synthesis for Dynamic Embodied Simulation](https://arxiv.org/abs/2608.26947), Zehao Qi et al., Arxiv 2026 | [citation](./references/citations.bib#L3390-L3395) | [site]() | [code]()
+
+- [SpatialCrafter: Single Image World Modeling with Generative 3D Proxies](https://arxiv.org/abs/2608.27073), Chuan Fang et al., SIGGRAPH Asia 2026 | [citation](./references/citations.bib#L3397-L3402) | [site](https://fangchuan.github.io/SpatialCrafter/) | [code]()
 
 </details>
 

--- a/references/citations.bib
+++ b/references/citations.bib
@@ -3379,3 +3379,24 @@ url={https://openreview.net/forum?id=1recIOnzOF}
   journal={arXiv preprint arXiv:2608.24109},
   year={2026}
 }
+
+@article{kim2026crossplatform,
+  title={Cross-Platform Benchmark of Neural 3D Reconstruction for Autonomous Laboratory Robots},
+  author={Kim, Yongho and Han, Mengjiao and Mateevitsi, Victor and Rizzi, Silvio and Papka, Michael E. and Ferrier, Nicola},
+  journal={arXiv preprint arXiv:2608.26383},
+  year={2026}
+}
+
+@article{qi20264dsynth,
+  title={4DSynth: Controllable Procedural World Synthesis for Dynamic Embodied Simulation},
+  author={Qi, Zehao and Luo, Haochen and Bian, Jia-Wang and Ma, Zeyu and Sun, Shuyang},
+  journal={arXiv preprint arXiv:2608.26947},
+  year={2026}
+}
+
+@inproceedings{fang2026spatialcrafter,
+  title={SpatialCrafter: Single Image World Modeling with Generative 3D Proxies},
+  author={Fang, Chuan and Qiu, Lingteng and Liang, Yixun and Chen, Rui and Luo, Kunming and Zheng, Zhaohua and Bai, Tongyuan and Tian, Feipeng and Dong, Zilong and Zhou, Zihan and Tan, Ping},
+  booktitle={SIGGRAPH Asia},
+  year={2026}
+}


### PR DESCRIPTION
Add SpatialCrafter and 4DSynth under World Models, and add the cross-platform neural 3D reconstruction benchmark under X-to-3D. Includes matching BibTeX entries and citation anchors.