### PR TITLE
Add Taxon3D (blind human-vote arena for 3D models of organisms) to Frameworks & Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,8 @@ This README is intended to work as a fast research index:
 
 ## Frameworks & Projects :desktop_computer:
 
+- [Taxon3D - Blind pairwise arena ranking text-to-3D and image-to-3D models on living organisms, with reference photographs and an admissibility gate](https://taxon3d.org), Jaret Arnold, Web 2026 | [code](https://github.com/musharna/taxon3d) | [data](https://huggingface.co/datasets/musharna/taxon3d-corpus-v1)
+
 - [Xiaomi-Robotics-0: An Open-Sourced Vision-Language-Action Model with Real-Time Execution](https://arxiv.org/abs/2602.12684), Rui Cai et al., Arxiv 2026 | [citation](./references/citations.bib#L2977-L2982) | [site](https://xiaomi-robotics-0.github.io/) | [code](https://github.com/XiaomiRobotics/Xiaomi-Robotics-0) | <a href="./references/internal-citations.md#s2-ae8aa1cced293fd9134c2c9757f419c68a17e4d9" title="No indexed papers cite this paper yet.">▲</a> citation count: 0
 
 - [WorldGen - Generate Any 3D Scene in Seconds](https://worldgen.github.io), Ziyang et al., Github 2026 | [code](https://github.com/ZiYang-xie/WorldGen)


### PR DESCRIPTION
Adds [Taxon3D](https://taxon3d.org) under Frameworks & Projects.

Taxon3D is a live, MIT-licensed, Chatbot-Arena-style site that ranks text-to-3D and image-to-3D models by blind pairwise human votes on living organisms (plants, fungi, animals), with CC-licensed reference photographs beside every pair and a fail-closed admissibility gate before voting. Rankings are Bradley–Terry with bootstrap 95% CIs. The text-to-3D board currently ranks Meshy, Tripo, Hunyuan3D and Rodin text models; image-to-3D covers Meshy, TRELLIS, Hunyuan3D, SAM 3D, Rodin, Pixal3D and TripoSR.

Code: https://github.com/musharna/taxon3d · Data (votes + redistributable meshes): https://huggingface.co/datasets/musharna/taxon3d-corpus-v1

Entry follows the existing format in the section (title, author, venue/year, code link).